### PR TITLE
wtf: a better `man`

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,24 @@
+# ==========================
+# wtf .env.template
+# Copy to `.env`, fill in values, then:
+#   set -a; source .env; set +a
+# ==========================
+
+# REQUIRED: OpenAI API key
+# Keep quotes to avoid shell parsing issues with special chars.
+OPENAI_API_KEY="sk-your-api-key"
+
+# OPTIONAL: Model override used by the script
+# Defaults to gpt-4o if unset. Shorthands: 4o, 4o-mini, 4.1
+WTF_LLM_MODEL="gpt-4o"
+
+# OPTIONAL: Override base URL (only if using a compatible proxy/gateway)
+# Leave commented for the default (https://api.openai.com).
+# OPENAI_BASE_URL="https://api.openai.com"
+
+# OPTIONAL: HTTP(S) proxy settings (urllib honors these)
+# HTTPS_PROXY="http://127.0.0.1:8080"
+# HTTP_PROXY="http://127.0.0.1:8080"
+
+# OPTIONAL: If you use direnv or dotenvx, leave as-is; they’ll load this automatically.
+

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Specific to WTF
+bin/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,150 @@
+# wtf
+
+Tiny, no-deps (stdlib-only) Python CLI for OpenAI’s **Responses API**.
+
+- Sends your prompt with a lightweight **system `instructions`**.
+- Attempts **web search** via the built-in tool; falls back cleanly if unsupported.
+- Prints only the model’s text to **stdout**.
+- Shows a playful **spinner** (e.g., “serving brainrot…”) on **stderr** while it thinks.
+- No venv required. Single file.
+
+## Quick start
+
+```bash
+# 1) Put the script somewhere on your PATH
+mkdir -p ~/.local/bin # for example
+cp wtf.py ~/.local/bin/wtf
+chmod +x ~/.local/bin/wtf
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc  # or ~/.zshrc
+exec $SHELL -l
+
+# 2) Set your key
+export OPENAI_API_KEY=sk-...
+
+# 3) Use it
+wtf "short: parquet on S3 vs ingesting into DuckDB?"
+```
+
+### macOS notes
+
+- Works in Terminal/iTerm (zsh/bash).
+- If `~/.local/bin` isn’t on PATH, add it in `~/.zshrc` or `~/.bash_profile`.
+
+### Ubuntu notes
+
+- Same as above. Uses the system’s `python3`.
+
+### Windows options
+
+- **Best:** WSL (Ubuntu). Put `wtf` in `~/bin` and add to PATH.
+
+- **Native without WSL:** Save as `wtf.py`, ensure `.py` is associated with Python launcher, and place on PATH so you can run `wtf "..."`.
+   Optional wrapper `wtf.cmd` (same directory):
+
+  ```cmd
+  @echo off
+  py "%~dp0wtf.py" %*
+  ```
+
+## Requirements
+
+- **Python:** 3.8+ (stdlib only: `urllib`, `json`, `threading`).
+- **No venv needed.** No `pip` dependencies.
+
+## Environment variables
+
+- `OPENAI_API_KEY` *(required)* — your API key.
+- `WTF_LLM_MODEL` *(optional)* — model name; defaults to `gpt-4o`.
+   Shorthands supported: `4o`, `4o-mini`, `4.1`, `5`.
+- `OPENAI_BASE_URL` *(optional)* — override the base URL (e.g., a compatible proxy). Default: `https://api.openai.com`.
+- `WTF_PHRASE_DELAY` *(optional)* — spinner phrase duration (how often to change phrases), in seconds (float). Default: `1.0`. 
+
+## Usage
+
+```bash
+wtf "explain vector similarity like I'm 5"
+wtf "longer answer: compare Parquet-on-S3 vs ingesting to DuckDB, include tradeoffs"
+wtf "give me a 1-line jq to extract the first field"
+```
+
+- Output is **ASCII-only** to keep terminals happy.
+- **Spinner** runs on stderr and won’t pollute pipelines:
+
+```bash
+wtf "one-liner to list files by size desc" | pbcopy   # macOS
+wtf "generate a bash for-loop example" | xclip -sel clip  # Linux
+```
+
+To suppress the spinner entirely:
+
+```bash
+wtf "..." 2>/dev/null
+```
+
+## Behavior details
+
+- **System prompt** is provided via top-level `instructions` (kept short, terminal-friendly).
+- **Input** uses the simple string form (`"input": "..."`).
+- **Web search**: the script sends `tools: [{"type": "web_search"}]`.
+   If the model/account doesn’t support it, the script **auto-retries without tools**.
+- **Errors** go to **stderr** with non-zero exit codes.
+  - `2` = usage error (no prompt)
+  - `1` = request/parse failure
+  - `0` = success
+
+## Security
+
+Treat `OPENAI_API_KEY` like any other secret:
+
+- Don’t commit it.
+- Consider using your shell’s secret manager or an `.env` that’s `.gitignore`’d.
+
+## FAQ / Troubleshooting
+
+**It says:** `ERROR: OPENAI_API_KEY is not set.`
+ → Export your key (`export OPENAI_API_KEY=...`) in your shell profile.
+
+**HTTP 400 invalid type (`'text'` vs `'input_text'`)**
+ → This script already uses the correct schema (`instructions` + string `input`). If you edited it to the structured form, ensure you use `{"type": "input_text"}` for user inputs.
+
+**I need Unicode output.**
+ → Replace the last line with:
+
+```python
+print(text)
+```
+
+(Currently we strip to ASCII for better terminal compatibility.)
+
+**I don’t want the spinner messages.**
+ → Redirect stderr: `wtf "..." 2>/dev/null`.
+
+**I want to force-disable web search.**
+ → Remove the `tools` line in the payload or comment it out.
+
+**Point to a proxy / mirror?**
+ → Set `OPENAI_BASE_URL` to your compatible endpoint.
+
+## Example session
+
+```bash
+export OPENAI_API_KEY=sk-...
+export WTF_LLM_MODEL=4o   # optional
+
+wtf "short: best practice for DuckDB parquet on S3?"
+# [spinner on stderr: "[/] spinning up neurons...", etc...]
+# stdout: "Use partitioned Parquet + object store caching, pushdown filters, and avoid tiny files; consider local caching with s3:// and enable parallel scans."
+```
+
+## File layout
+
+```
+.
+├── wtf            # the single-file Python script (executable)
+├── .env.template  # env vars used by wtf
+└── README.md      # this file
+```
+
+## License
+
+License? For this? I don't think so. Use it however you want. lol

--- a/wtf.py
+++ b/wtf.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# wtf: tiny Python client for OpenAI Responses API
+# Deps: stdlib only (urllib, json, threading)
+
+import json, os, sys, time, threading, random
+from urllib import request, error
+
+INSTRUCTIONS = (
+    "You should respond to the user's prompt in a helpful and respectful way. "
+    "Your response will be displayed in a linux terminal, as the output of a command from the user. "
+    "It should contain only ASCII character that will display properly in a standard Gnome terminal window. "
+    "It should be as brief as possible, while still answering the question. "
+    "However, the user can override this brevity stipulation by explicitly requesting a longer or more detailed "
+    "response in their prompt, and you must respect such requests."
+)
+
+def die(msg, code=1):
+    print(f"ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+if len(sys.argv) < 2:
+    die(f"Usage: {os.path.basename(sys.argv[0])} \"your prompt here\"", 2)
+
+api_key = os.getenv("OPENAI_API_KEY") or die("OPENAI_API_KEY is not set.")
+model = os.getenv("WTF_LLM_MODEL", "gpt-4o")
+aliases = {"4o": "gpt-4o", "4o-mini": "gpt-4o-mini", "4.1": "gpt-4.1", "5":"gpt-5"}
+model = aliases.get(model.lower(), model)
+
+base_url = (os.getenv("OPENAI_BASE_URL") or "https://api.openai.com").rstrip("/")
+endpoint = f"{base_url}/v1/responses"
+prompt = " ".join(sys.argv[1:])
+
+# -------- spinner (stderr only, to keep stdout clean) ----------
+def spinner(stop_event):
+    if not sys.stderr.isatty():
+        return
+    phrases = [
+        "thinking...", "vibing in Ohio...", "loading vibes...",
+        "cooking...", "chewing on this...", "spinning up neurons...",
+        "summoning citations...", "buffering brilliance...",
+        "optimizing takes...", "deep in the sauce...", "caffeinating ideas...",
+        "low-latency daydreaming...", "min-maxing the answer...", "nerd sniping myself...", "feeling skibbidy..."
+    ]
+    random.shuffle(phrases)
+    glyphs = "|/-\\"
+    phrase_idx = 0
+    glyph_idx = 0
+    width = 78
+    glyph_delay = 0.25
+    while not stop_event.is_set():
+        msg = f"[{glyphs[glyph_idx % len(glyphs)]}] {phrases[phrase_idx % len(phrases)]}"
+        sys.stderr.write("\r" + msg[:width].ljust(width))
+        sys.stderr.flush()
+        glyph_idx += 1
+        time.sleep(glyph_delay)
+        if glyph_idx % len(glyphs) == 0:
+            phrase_idx += 1
+    # clear line
+    sys.stderr.write("\r" + " " * width + "\r")
+    sys.stderr.flush()
+
+def do_request(payload):
+    data = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        endpoint, data=data, method="POST",
+        headers={"Authorization": f"Bearer {api_key}",
+                 "Content-Type": "application/json",
+                 "Accept": "application/json"}
+    )
+    try:
+        with request.urlopen(req, timeout=60) as resp:
+            status, body = resp.status, resp.read()
+    except error.HTTPError as e:
+        status, body = e.code, e.read()
+    except Exception as e:
+        die(f"Request failed: {e}")
+    try:
+        j = json.loads(body.decode("utf-8", errors="replace"))
+    except Exception:
+        die(f"Non-JSON response (HTTP {status}): {body[:1000]!r}")
+    return status, j
+
+def extract_text(rj):
+    t = rj.get("output_text")
+    if isinstance(t, str) and t:
+        return t
+    out = rj.get("output")
+    if isinstance(out, list):
+        parts = []
+        for item in out:
+            if item.get("type") == "message":
+                for c in item.get("content", []):
+                    if c.get("type") in ("output_text", "text"):
+                        s = c.get("text")
+                        if isinstance(s, str):
+                            parts.append(s)
+        if parts:
+            return "".join(parts)
+    ch = rj.get("choices")
+    if isinstance(ch, list) and ch:
+        msg = ch[0].get("message") or {}
+        if isinstance(msg, dict) and isinstance(msg.get("content"), str):
+            return msg["content"]
+    return ""
+
+def web_tool_unsupported(rj):
+    err = rj.get("error")
+    msg = (err.get("message") if isinstance(err, dict) else str(err or "")).lower()
+    return ("web_search" in msg) and ("unsupported" in msg or "not supported" in msg or "tool" in msg)
+
+# Build payloads
+payload_with_web = {
+    "model": model,
+    "instructions": INSTRUCTIONS,   # acts like system prompt
+    "input": prompt,                # simplest valid input shape
+    "tools": [ { "type": "web_search" } ]  # may be rejected; we'll fall back
+}
+payload_no_web = {
+    "model": model,
+    "instructions": INSTRUCTIONS,
+    "input": prompt
+}
+
+stop = threading.Event()
+t = None
+try:
+    if sys.stderr.isatty():
+        t = threading.Thread(target=spinner, args=(stop,), daemon=True)
+        t.start()
+
+    status, j = do_request(payload_with_web)
+    if status != 200 and web_tool_unsupported(j):
+        status, j = do_request(payload_no_web)
+finally:
+    stop.set()
+    if t:
+        t.join()
+
+if status != 200:
+    err = j.get("error") or j
+    msg = err.get("message") if isinstance(err, dict) else err
+    die(f"OpenAI API request failed (HTTP {status})\nDetails: {msg}")
+
+text = extract_text(j)
+if not text:
+    die("No text content found in API response.\n" + json.dumps(j, indent=2)[:2000])
+
+# Terminal-friendly ASCII only on stdout
+print(text.encode("ascii", "ignore").decode("ascii"))


### PR DESCRIPTION
## Summary by Sourcery

Add a new single-file Python CLI tool "wtf" for interacting with OpenAI’s Responses API, featuring stdlib-only dependencies, a stderr spinner, web‐search fallback, and ASCII‐only output, along with accompanying documentation and an .env template.

New Features:
- Introduce a standalone Python CLI script (wtf) that sends prompts to the OpenAI Responses API using only the standard library
- Show a playful spinner on stderr during API requests
- Attempt web search via the built-in tool and gracefully retry without tools if unsupported
- Strip API responses to ASCII and print only the model’s text to stdout

Documentation:
- Add a comprehensive README with installation, usage, environment variables, platform notes, and troubleshooting
- Include an .env.template for environment variable configuration